### PR TITLE
Remove pin from IRL Whiteboard Practice Night post

### DIFF
--- a/docs/posts/2026/03/13/index.md
+++ b/docs/posts/2026/03/13/index.md
@@ -14,7 +14,6 @@ tags:
   - beginner-friendly
   - irl
   - edmonton
-pin: true
 ---
 
 Join Weekly Dev Chat for a whiteboard practice night focused on explaining your thinking clearly while solving coding problems — a skill that matters in interviews and on the job.


### PR DESCRIPTION
Eliminate the pinning of the IRL Whiteboard Practice Night as the event has passed.