### PR TITLE
Fix deployment by installing all dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install -r requirements.txt 
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Update the deployment process to install all dependencies from `requirements.txt`, resolving the deployment failure caused by the recent changes in PR #118.  The failed action is:

https://github.com/weeklydevchat/weeklydevchat.github.io/actions/runs/26522814683/job/78118319656

The error is:

```
Run mkdocs gh-deploy --force

 │  ⚠  Warning from the Material for MkDocs team
 │
 │  MkDocs 2.0, the underlying framework of Material for MkDocs,
 │  will introduce backward-incompatible changes, including:
 │
 │  × All plugins will stop working – the plugin system has been removed
 │  × All theme overrides will break – the theming system has been rewritten
 │  × No migration path exists – existing projects cannot be upgraded
 │  × Closed contribution model – community members can't report bugs
 │  × Currently unlicensed – unsuitable for production use
 │
 │  Our full analysis:
 │
 │  https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

ERROR   -  Config value 'plugins': The "macros" plugin is not installed

Aborted with a configuration error!
Error: Process completed with exit code 1.
```