### PR TITLE
Fixes 'join' links in old posts

### DIFF
--- a/docs/posts/2025/02/2025-02-25-habits/index.md
+++ b/docs/posts/2025/02/2025-02-25-habits/index.md
@@ -13,6 +13,6 @@ tags:
 
 Join us Feb 25th, 2025 as we discuss our worst software development habits. What is one software development best practice you know you should do but don’t? A best practice you know you need to improve? Spoiler alert, but for me it’s logging. I always forget to add logging to my code and then struggle when a production error occurs, but I can’t debug it in my development environment.
 
-Everyone and anyone are welcome to join as long as you are kind, supportive, and respectful of others. Learn how to join the chat, and other useful information, [here](/join/).
+Everyone and anyone are welcome to join as long as you are kind, supportive, and respectful of others. Learn how to join the chat, and other useful information, [here](../../../../join.md).
 
 ![alt text](WDC_2025-02-25.webp)

--- a/docs/posts/2025/03/04/index.md
+++ b/docs/posts/2025/03/04/index.md
@@ -13,6 +13,6 @@ tags:
 
 Today we're discussing software development supply chains. For example, are your dependencies completely open source, or do you buy commercial libraries?   Do you rely on tools like Balsamiq, or Adobe Photoshop/Illustrator? Are you deploying your software in the cloud or on-site? Do you sell your work in any of the app stores?
 
-Everyone and anyone are welcome to join as long as you are kind, supportive, and respectful of others. Learn how to join the chat, and other useful information, [here](/join/).
+Everyone and anyone are welcome to join as long as you are kind, supportive, and respectful of others. Learn how to join the chat, and other useful information, [here](../../../../join.md).
 
 ![alt text](WDC_2025-03-04.webp)


### PR DESCRIPTION
Absolute links create warnings in build.  This changes them to relative.  Only two old posts