### PR TITLE
Install dev dependencies in Docker setup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-uv sync --frozen --no-dev   # or remove --no-dev if you want dev deps
+uv sync --frozen
 
 # Optional: make sure mkdocs is in PATH
 export PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
Update the Docker setup to install development dependencies.  The Docker setup is only used in development and not production.